### PR TITLE
fix: improve OGP metadata for Discord embeds

### DIFF
--- a/packages/blog/src/components/organisms/SeoHead/index.tsx
+++ b/packages/blog/src/components/organisms/SeoHead/index.tsx
@@ -1,4 +1,19 @@
-import { BASE_URL } from '@blog/libs/const';
+import {
+  BASE_URL,
+  BLOG_DEFAULT_TITLE,
+  BLOG_DESCRIPTION,
+  BLOG_TITLE,
+  OG_LOCALE,
+  TWITTER_SITE,
+} from '@blog/libs/const';
+import {
+  DEFAULT_OG_IMAGE,
+  DEFAULT_OG_IMAGE_ALT,
+  DEFAULT_OG_IMAGE_HEIGHT,
+  DEFAULT_OG_IMAGE_TYPE,
+  DEFAULT_OG_IMAGE_WIDTH,
+  DEFAULT_TWITTER_IMAGE,
+} from '@blog/libs/ogImage';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import React from 'react';
@@ -7,59 +22,81 @@ interface Props {}
 
 export const SeoHead: React.FC<Props> = ({}) => {
   const router = useRouter();
-  const currentPath = router.asPath;
-  const sitePath = `${BASE_URL}${currentPath}`;
-
-  const isContentPage =
-    currentPath.startsWith('/post/') || currentPath.match('^/til/.+ ');
+  const currentPath = router.asPath.split('#')[0]?.split('?')[0] || '/';
+  const sitePath = new URL(currentPath, BASE_URL).toString();
 
   return (
     <Head>
-      <meta data-hid="charset" charSet="utf-8" />
-      <meta name="viewport" content="width=device-width, initial-scale=1" />
-      {!isContentPage && (
-        <>
-          <meta
-            name="description"
-            content="sa2taka/t0p_l1ghtの独断と偏見が混じった、エンジニア、プログラマーのためのニッチな記事を残すブログです。"
-          />
-          <meta
-            data-hid="og:title"
-            property="og:title"
-            content="言葉の向こうに世界を見る | sa2taka blog"
-          />
-          <meta
-            data-hid="og:description"
-            property="og:description"
-            content="sa2taka/t0p_l1ghtの独断と偏見が混じった、エンジニア、プログラマーのためのニッチな記事を残すブログです。"
-          />
-        </>
-      )}
-      <meta data-hid="og:type" property="og:type" content="website" />
+      <meta key="charset" data-hid="charset" charSet="utf-8" />
       <meta
-        data-hid="og:image"
-        property="og:image"
-        content="https://blog.sa2taka.com/logo-for-facebook.png"
-      />
-      <meta data-hid="twitter:card" property="twitter:card" content="summary" />
-      <meta
-        data-hid="twitter:image"
-        property="twitter:image"
-        content="https://blog.sa2taka.com/logo-for-twitter.png"
+        key="viewport"
+        name="viewport"
+        content="width=device-width, initial-scale=1"
       />
       <meta
-        data-hid="twitter:site"
-        property="twitter:site"
-        content="@t0p_l1ght"
+        key="description"
+        name="description"
+        content={BLOG_DESCRIPTION}
+      />
+      <meta key="og:title" property="og:title" content={BLOG_DEFAULT_TITLE} />
+      <meta
+        key="og:description"
+        property="og:description"
+        content={BLOG_DESCRIPTION}
+      />
+      <meta key="og:type" property="og:type" content="website" />
+      <meta key="og:image" property="og:image" content={DEFAULT_OG_IMAGE} />
+      <meta
+        key="og:image:secure_url"
+        property="og:image:secure_url"
+        content={DEFAULT_OG_IMAGE}
       />
       <meta
-        data-hid="og:site_name"
-        property="og:site_name"
-        content="言葉の向こうに世界を見る"
+        key="og:image:type"
+        property="og:image:type"
+        content={DEFAULT_OG_IMAGE_TYPE}
       />
-      <meta data-hid="og:url" property="og:url" content={sitePath} />
-
-      <link rel="canonical" href={sitePath} />
+      <meta
+        key="og:image:width"
+        property="og:image:width"
+        content={DEFAULT_OG_IMAGE_WIDTH.toString()}
+      />
+      <meta
+        key="og:image:height"
+        property="og:image:height"
+        content={DEFAULT_OG_IMAGE_HEIGHT.toString()}
+      />
+      <meta
+        key="og:image:alt"
+        property="og:image:alt"
+        content={DEFAULT_OG_IMAGE_ALT}
+      />
+      <meta key="og:locale" property="og:locale" content={OG_LOCALE} />
+      <meta key="og:site_name" property="og:site_name" content={BLOG_TITLE} />
+      <meta key="og:url" property="og:url" content={sitePath} />
+      <meta key="twitter:card" name="twitter:card" content="summary" />
+      <meta
+        key="twitter:title"
+        name="twitter:title"
+        content={BLOG_DEFAULT_TITLE}
+      />
+      <meta
+        key="twitter:description"
+        name="twitter:description"
+        content={BLOG_DESCRIPTION}
+      />
+      <meta
+        key="twitter:image"
+        name="twitter:image"
+        content={DEFAULT_TWITTER_IMAGE}
+      />
+      <meta
+        key="twitter:image:alt"
+        name="twitter:image:alt"
+        content={DEFAULT_OG_IMAGE_ALT}
+      />
+      <meta key="twitter:site" name="twitter:site" content={TWITTER_SITE} />
+      <link key="canonical" rel="canonical" href={sitePath} />
     </Head>
   );
 };

--- a/packages/blog/src/libs/const.ts
+++ b/packages/blog/src/libs/const.ts
@@ -1,5 +1,10 @@
 export const BLOG_TITLE = '言葉の向こうに世界を見る';
+export const BLOG_DEFAULT_TITLE = `${BLOG_TITLE} | sa2taka blog`;
+export const BLOG_DESCRIPTION =
+  'sa2taka/t0p_l1ghtの独断と偏見が混じった、エンジニア、プログラマーのためのニッチな記事を残すブログです。';
 export const BASE_URL = 'https://blog.sa2taka.com';
 export const AUTHOR = 'sa2taka';
+export const OG_LOCALE = 'ja_JP';
 export const POSTS_LIMIT = 40;
 export const TIL_LIMIT = 100;
+export const TWITTER_SITE = '@t0p_l1ght';

--- a/packages/blog/src/libs/ogImage.ts
+++ b/packages/blog/src/libs/ogImage.ts
@@ -1,7 +1,11 @@
-import { BASE_URL } from './const';
+import { BASE_URL, BLOG_TITLE } from './const';
 
 export const DEFAULT_OG_IMAGE = `${BASE_URL}/logo-for-facebook.png`;
 export const DEFAULT_TWITTER_IMAGE = `${BASE_URL}/logo-for-twitter.png`;
+export const DEFAULT_OG_IMAGE_ALT = `${BLOG_TITLE} の OGP 画像`;
+export const DEFAULT_OG_IMAGE_HEIGHT = 630;
+export const DEFAULT_OG_IMAGE_TYPE = 'image/png';
+export const DEFAULT_OG_IMAGE_WIDTH = 1200;
 
 /**
  * ogImageの値を絶対URLに変換する

--- a/packages/blog/src/pages/guide.tsx
+++ b/packages/blog/src/pages/guide.tsx
@@ -8,18 +8,18 @@ const Guide = () => {
       <Head>
         <title>プライバシーポリシー・利用ガイドライン</title>
         <meta
-          data-hid="description"
+          key="description"
           name="description"
           content="プライバシーポリシー・利用ガイドライン"
         />
         <meta
-          data-hid="og:title"
-          name="og:title"
+          key="og:title"
+          property="og:title"
           content="プライバシーポリシー・利用ガイドライン"
         />
         <meta
-          data-hid="og:description"
-          name="og:description"
+          key="og:description"
+          property="og:description"
           content="プライバシーポリシー・利用ガイドライン"
         />
       </Head>

--- a/packages/blog/src/pages/post/[slug].tsx
+++ b/packages/blog/src/pages/post/[slug].tsx
@@ -1,15 +1,19 @@
 import { Breadcrumbs } from '@blog/components/molecules/Breadcrumbs';
-import { Post } from '@blog/types/entry';
-import { GetStaticPaths, GetStaticProps } from 'next';
-import React, { useMemo } from 'react';
-import { PostIndexItem } from '@blog/types/postIndex';
-import { generatePostBreadcrumbsList } from '@blog/libs/breadcrumbsGenerator';
 import { PostArea } from '@blog/components/organisms/PostArea';
+import { generatePostBreadcrumbsList } from '@blog/libs/breadcrumbsGenerator';
+import { AUTHOR, BASE_URL, BLOG_TITLE, TWITTER_SITE } from '@blog/libs/const';
+import {
+  DEFAULT_OG_IMAGE_ALT,
+  DEFAULT_TWITTER_IMAGE,
+  resolveOgImageUrl,
+} from '@blog/libs/ogImage';
+import { Post } from '@blog/types/entry';
+import { PostIndexItem } from '@blog/types/postIndex';
+import { GetStaticPaths, GetStaticProps } from 'next';
 import Head from 'next/head';
-import Script from 'next/script';
-import { AUTHOR, BASE_URL } from '@blog/libs/const';
-import { resolveOgImageUrl } from '@blog/libs/ogImage';
 import { useRouter } from 'next/router';
+import Script from 'next/script';
+import React, { useMemo } from 'react';
 
 interface Props {
   post: Post;
@@ -67,21 +71,19 @@ export const getStaticProps: GetStaticProps<Props> = async (context) => {
 };
 
 const getSeoStructureData = (post: Post, path: string) => {
-  const image = post.ogImage
-    ? resolveOgImageUrl(post.ogImage)
-    : BASE_URL + '/logo.png';
+  const image = resolveOgImageUrl(post.ogImage);
 
   return {
     '@context': 'https://schema.org',
     '@type': 'BlogPosting',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': BASE_URL + path,
+      '@id': new URL(path, BASE_URL).toString(),
     },
     headline: post.title,
     image: [image],
-    datePublished: post.createdAt.toString(),
-    dateModified: post.updatedAt.toString(),
+    datePublished: new Date(post.createdAt).toISOString(),
+    dateModified: new Date(post.updatedAt).toISOString(),
     author: {
       '@type': 'Person',
       name: AUTHOR,
@@ -91,43 +93,87 @@ const getSeoStructureData = (post: Post, path: string) => {
       name: 'sa2taka',
       logo: {
         '@type': 'ImageObject',
-        url: BASE_URL + '/logo-for-twitter.png',
+        url: DEFAULT_TWITTER_IMAGE,
       },
     },
   };
 };
+
 const PostHead: React.FC<{ post: Post }> = ({ post }) => {
   const router = useRouter();
-  const path = router.pathname;
+  const path = router.asPath.split('#')[0]?.split('?')[0] || '/';
+  const pageUrl = new URL(path, BASE_URL).toString();
   const ogImageUrl = resolveOgImageUrl(post.ogImage);
+  const hasCustomOgImage = Boolean(post.ogImage);
+  const socialImageAlt = hasCustomOgImage
+    ? `${post.title} の OGP 画像`
+    : DEFAULT_OG_IMAGE_ALT;
 
   return (
     <Head>
       <title>{post.title}</title>
       <meta
-        data-hid="description"
+        key="description"
         name="description"
         content={post.description}
       />
-      <meta data-hid="og:title" name="og:title" content={post.title} />
+      <meta key="og:title" property="og:title" content={post.title} />
       <meta
-        data-hid="og:description"
-        name="og:description"
+        key="og:description"
+        property="og:description"
         content={post.description}
       />
-      <meta data-hid="og:image" property="og:image" content={ogImageUrl} />
+      <meta key="og:type" property="og:type" content="article" />
+      <meta key="og:url" property="og:url" content={pageUrl} />
+      <meta key="og:site_name" property="og:site_name" content={BLOG_TITLE} />
+      <meta key="og:image" property="og:image" content={ogImageUrl} />
       <meta
-        data-hid="twitter:image"
-        property="twitter:image"
+        key="og:image:secure_url"
+        property="og:image:secure_url"
         content={ogImageUrl}
       />
-      {post.ogImage && (
-        <meta
-          data-hid="twitter:card"
-          property="twitter:card"
-          content="summary_large_image"
-        />
-      )}
+      <meta
+        key="og:image:alt"
+        property="og:image:alt"
+        content={socialImageAlt}
+      />
+      <meta
+        key="article:published_time"
+        property="article:published_time"
+        content={new Date(post.createdAt).toISOString()}
+      />
+      <meta
+        key="article:modified_time"
+        property="article:modified_time"
+        content={new Date(post.updatedAt).toISOString()}
+      />
+      <meta key="twitter:title" name="twitter:title" content={post.title} />
+      <meta
+        key="twitter:description"
+        name="twitter:description"
+        content={post.description}
+      />
+      <meta
+        key="twitter:image"
+        name="twitter:image"
+        content={ogImageUrl}
+      />
+      <meta
+        key="twitter:image:alt"
+        name="twitter:image:alt"
+        content={socialImageAlt}
+      />
+      <meta
+        key="twitter:card"
+        name="twitter:card"
+        content={hasCustomOgImage ? 'summary_large_image' : 'summary'}
+      />
+      <meta key="twitter:site" name="twitter:site" content={TWITTER_SITE} />
+      <meta
+        key="twitter:creator"
+        name="twitter:creator"
+        content={TWITTER_SITE}
+      />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/packages/blog/src/pages/til/[slug].tsx
+++ b/packages/blog/src/pages/til/[slug].tsx
@@ -1,8 +1,12 @@
 import { Breadcrumbs } from '@blog/components/molecules/Breadcrumbs';
 import { TilItem } from '@blog/components/organisms/Tils/TilItem';
 import { generateTilBreadcrumbsList } from '@blog/libs/breadcrumbsGenerator';
-import { AUTHOR, BASE_URL } from '@blog/libs/const';
-import { resolveOgImageUrl } from '@blog/libs/ogImage';
+import { AUTHOR, BASE_URL, BLOG_TITLE, TWITTER_SITE } from '@blog/libs/const';
+import {
+  DEFAULT_OG_IMAGE_ALT,
+  DEFAULT_TWITTER_IMAGE,
+  resolveOgImageUrl,
+} from '@blog/libs/ogImage';
 import { TilWithRawHtml } from '@blog/types/entry';
 import { GetStaticPaths, GetStaticProps } from 'next';
 import Head from 'next/head';
@@ -61,21 +65,19 @@ export const getStaticProps: GetStaticProps<Props> = async (context) => {
 };
 
 const getSeoStructureData = (til: TilWithRawHtml, path: string) => {
-  const image = til.ogImage
-    ? resolveOgImageUrl(til.ogImage)
-    : BASE_URL + '/logo.png';
+  const image = resolveOgImageUrl(til.ogImage);
 
   return {
     '@context': 'https://schema.org',
     '@type': 'BlogPosting',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': BASE_URL + path,
+      '@id': new URL(path, BASE_URL).toString(),
     },
     headline: til.title,
     image: [image],
-    datePublished: til.createdAt.toString(),
-    dateModified: til.updatedAt.toString(),
+    datePublished: new Date(til.createdAt).toISOString(),
+    dateModified: new Date(til.updatedAt).toISOString(),
     author: {
       '@type': 'Person',
       name: AUTHOR,
@@ -85,15 +87,21 @@ const getSeoStructureData = (til: TilWithRawHtml, path: string) => {
       name: 'sa2taka',
       logo: {
         '@type': 'ImageObject',
-        url: BASE_URL + '/logo-for-twitter.png',
+        url: DEFAULT_TWITTER_IMAGE,
       },
     },
   };
 };
+
 const TilHead: React.FC<{ til: TilWithRawHtml }> = ({ til }) => {
   const router = useRouter();
-  const path = router.pathname;
+  const path = router.asPath.split('#')[0]?.split('?')[0] || '/';
+  const pageUrl = new URL(path, BASE_URL).toString();
   const ogImageUrl = resolveOgImageUrl(til.ogImage);
+  const hasCustomOgImage = Boolean(til.ogImage);
+  const socialImageAlt = hasCustomOgImage
+    ? `${til.title} の OGP 画像`
+    : DEFAULT_OG_IMAGE_ALT;
 
   const description =
     til.body.length > 200 ? til.body.slice(0, 200) + '...' : til.body;
@@ -101,26 +109,64 @@ const TilHead: React.FC<{ til: TilWithRawHtml }> = ({ til }) => {
   return (
     <Head>
       <title>{til.title}</title>
-      <meta data-hid="description" name="description" content={description} />
-      <meta data-hid="og:title" name="og:title" content={til.title} />
+      <meta key="description" name="description" content={description} />
+      <meta key="og:title" property="og:title" content={til.title} />
       <meta
-        data-hid="og:description"
-        name="og:description"
+        key="og:description"
+        property="og:description"
         content={description}
       />
-      <meta data-hid="og:image" property="og:image" content={ogImageUrl} />
+      <meta key="og:type" property="og:type" content="article" />
+      <meta key="og:url" property="og:url" content={pageUrl} />
+      <meta key="og:site_name" property="og:site_name" content={BLOG_TITLE} />
+      <meta key="og:image" property="og:image" content={ogImageUrl} />
       <meta
-        data-hid="twitter:image"
-        property="twitter:image"
+        key="og:image:secure_url"
+        property="og:image:secure_url"
         content={ogImageUrl}
       />
-      {til.ogImage && (
-        <meta
-          data-hid="twitter:card"
-          property="twitter:card"
-          content="summary_large_image"
-        />
-      )}
+      <meta
+        key="og:image:alt"
+        property="og:image:alt"
+        content={socialImageAlt}
+      />
+      <meta
+        key="article:published_time"
+        property="article:published_time"
+        content={new Date(til.createdAt).toISOString()}
+      />
+      <meta
+        key="article:modified_time"
+        property="article:modified_time"
+        content={new Date(til.updatedAt).toISOString()}
+      />
+      <meta key="twitter:title" name="twitter:title" content={til.title} />
+      <meta
+        key="twitter:description"
+        name="twitter:description"
+        content={description}
+      />
+      <meta
+        key="twitter:image"
+        name="twitter:image"
+        content={ogImageUrl}
+      />
+      <meta
+        key="twitter:image:alt"
+        name="twitter:image:alt"
+        content={socialImageAlt}
+      />
+      <meta
+        key="twitter:card"
+        name="twitter:card"
+        content={hasCustomOgImage ? 'summary_large_image' : 'summary'}
+      />
+      <meta key="twitter:site" name="twitter:site" content={TWITTER_SITE} />
+      <meta
+        key="twitter:creator"
+        name="twitter:creator"
+        content={TWITTER_SITE}
+      />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{


### PR DESCRIPTION
## Summary
- dedupe social metadata so article pages only expose one og:image/tw card
- align Open Graph tags with Discord-friendly attributes and article metadata
- fix structured data URLs to use the real page path
