### PR TITLE
feat: 日本語タイポグラフィをWindows中心に改善

### DIFF
--- a/packages/blog/src/components/molecules/MarkdownBody/index.module.css
+++ b/packages/blog/src/components/molecules/MarkdownBody/index.module.css
@@ -128,7 +128,6 @@
   overflow-x: auto;
   color: #ddd;
   background: #282c34;
-  font-weight: 500;
   /* 閲覧者のブラウザ設定の等幅フォントに委ねる。サイズはremで指定し、
      総称monospace時に相対サイズが等幅既定(13px)基準で縮む挙動を避ける */
   font-family: monospace;

--- a/packages/blog/src/components/molecules/MarkdownBody/index.module.css
+++ b/packages/blog/src/components/molecules/MarkdownBody/index.module.css
@@ -109,6 +109,18 @@
   margin-bottom: 20px;
 }
 
+.postBody h2,
+.postBody h3,
+.postBody h4,
+.postBody h5 {
+  line-height: 1.4;
+  letter-spacing: 0.01em;
+  /* paltで約物・仮名を詰める。auto-phrase/balanceで文節単位の自然な折り返しにする */
+  font-feature-settings: 'palt';
+  text-wrap: balance;
+  word-break: auto-phrase;
+}
+
 .postBody hr {
   margin-top: 12px;
   margin-bottom: 2em;
@@ -132,6 +144,9 @@
      総称monospace時に相対サイズが等幅既定(13px)基準で縮む挙動を避ける */
   font-family: monospace;
   font-size: 0.9375rem;
+  /* コードは桁揃えを保つため、和欧間アキ・約物詰めを無効にする */
+  text-autospace: no-autospace;
+  text-spacing-trim: space-all;
 }
 
 .postBody code :global(.token.prompt) {

--- a/packages/blog/src/components/molecules/MarkdownBody/index.module.css
+++ b/packages/blog/src/components/molecules/MarkdownBody/index.module.css
@@ -63,10 +63,15 @@
 
 .postBody :where(ul, ol) {
   margin-bottom: 1.8em;
+  padding-left: 1.6em;
+}
+
+.postBody li {
+  margin-bottom: 0.4em;
 }
 
 .postBody li > :is(ul, ol) {
-  margin-bottom: 0.5em;
+  margin-bottom: 0.4em;
 }
 
 .postBody blockquote :global(p.author) {
@@ -199,11 +204,6 @@
 
 .postBody :global(code.hljsComment) {
   color: #acb3c0;
-}
-
-.postBody ul,
-.postBody ol {
-  margin-left: 1.2em;
 }
 
 .postBody :global(.message) {

--- a/packages/blog/src/components/molecules/MarkdownBody/index.module.css
+++ b/packages/blog/src/components/molecules/MarkdownBody/index.module.css
@@ -129,6 +129,10 @@
   color: #ddd;
   background: #282c34;
   font-weight: 500;
+  /* 閲覧者のブラウザ設定の等幅フォントに委ねる。サイズはremで指定し、
+     総称monospace時に相対サイズが等幅既定(13px)基準で縮む挙動を避ける */
+  font-family: monospace;
+  font-size: 0.9375rem;
 }
 
 .postBody code :global(.token.prompt) {
@@ -329,7 +333,7 @@
   min-width: 5em;
   padding: 0.1em 0.3em 0.1em 1em;
 
-  font-size: 15px;
+  font-size: 0.9375rem;
   line-height: 1.5;
 
   margin: 0;

--- a/packages/blog/src/components/molecules/MarkdownBody/index.module.css
+++ b/packages/blog/src/components/molecules/MarkdownBody/index.module.css
@@ -154,6 +154,13 @@
   color: #777;
 }
 
+.postBody a {
+  text-decoration: underline;
+  /* 和文の字面や欧文ディセンダに下線が重ならない位置まで下げる */
+  text-underline-offset: 0.15em;
+  text-decoration-thickness: 1px;
+}
+
 :global(.theme--light) .postBody a {
   color: #006256;
 }

--- a/packages/blog/src/components/molecules/MarkdownBody/index.module.css
+++ b/packages/blog/src/components/molecules/MarkdownBody/index.module.css
@@ -31,6 +31,12 @@
   background: linear-gradient(transparent 80%, var(--secondary-color) 0%);
 }
 
+/* 和文にイタリック体がないため、強調はウェイトで表現する */
+.postBody em {
+  font-style: normal;
+  font-weight: 600;
+}
+
 .postBody blockquote {
   padding: 0.6em 1em;
   margin: 2em auto;

--- a/packages/blog/src/components/molecules/MarkdownBody/prismTheme.module.css
+++ b/packages/blog/src/components/molecules/MarkdownBody/prismTheme.module.css
@@ -19,7 +19,7 @@
 .prismTheme pre[class*='language-'],
 .prismTheme code[class*='language-'] {
   color: #dddddd;
-  font-size: 15px;
+  font-size: 0.9375rem;
   text-shadow: none;
   direction: ltr;
   text-align: left;

--- a/packages/blog/src/components/organisms/Pagination/index.module.css
+++ b/packages/blog/src/components/organisms/Pagination/index.module.css
@@ -7,7 +7,7 @@
   display: inline-flex;
   list-style-type: none;
   justify-content: center;
-  margin: 0;
+  margin: 24px 0;
   max-width: 100%;
   width: 100%;
   padding: 0;

--- a/packages/blog/src/components/organisms/PostArea/Information.module.css
+++ b/packages/blog/src/components/organisms/PostArea/Information.module.css
@@ -22,6 +22,9 @@
   margin: 0.4em auto;
   line-height: 1.4em;
   overflow-wrap: anywhere;
+  font-feature-settings: 'palt';
+  text-wrap: balance;
+  word-break: auto-phrase;
 }
 
 @media screen and (max-width: 768px) {

--- a/packages/blog/src/pages/category/[slug]/[page].tsx
+++ b/packages/blog/src/pages/category/[slug]/[page].tsx
@@ -92,6 +92,14 @@ export const getStaticProps: GetStaticProps<Props, Params> = async (
 
 const Page: NextPage<Props> = ({ count, page, posts, slug, category }) => {
   const breadcrumbsList = generateCategoryBreadcrumbsList(category);
+  const pagination = (
+    <Pagination
+      baseUrl={`/category/${slug}`}
+      currentPage={page}
+      limit={POSTS_LIMIT}
+      postsCount={count}
+    />
+  );
   return (
     <>
       <Head>
@@ -101,14 +109,10 @@ const Page: NextPage<Props> = ({ count, page, posts, slug, category }) => {
         <meta name="robots" content="noindex,nofollow" />
       </Head>
       <Breadcrumbs list={breadcrumbsList} />
-      <Pagination
-        baseUrl={`/category/${slug}`}
-        currentPage={page}
-        limit={POSTS_LIMIT}
-        postsCount={count}
-      />
+      {pagination}
       <h2 className={titleStyles.title}>{category.name}</h2>
       <Posts posts={posts} />
+      {pagination}
     </>
   );
 };

--- a/packages/blog/src/pages/category/[slug]/index.tsx
+++ b/packages/blog/src/pages/category/[slug]/index.tsx
@@ -88,6 +88,14 @@ export const getStaticProps: GetStaticProps<Props, Params> = async (
 
 const Page: NextPage<Props> = ({ count, posts, slug, category }) => {
   const breadcrumbsList = generateCategoryBreadcrumbsList(category);
+  const pagination = (
+    <Pagination
+      baseUrl={`/category/${slug}`}
+      currentPage={1}
+      limit={POSTS_LIMIT}
+      postsCount={count}
+    />
+  );
   return (
     <>
       <Head>
@@ -95,14 +103,10 @@ const Page: NextPage<Props> = ({ count, posts, slug, category }) => {
         <meta name="robots" content="noindex,nofollow" />
       </Head>
       <Breadcrumbs list={breadcrumbsList} />
-      <Pagination
-        baseUrl={`/category/${slug}`}
-        currentPage={1}
-        limit={POSTS_LIMIT}
-        postsCount={count}
-      />
+      {pagination}
       <h2 className={titleStyles.title}>{category.name}</h2>
       <Posts posts={posts} />
+      {pagination}
     </>
   );
 };

--- a/packages/blog/src/pages/index.tsx
+++ b/packages/blog/src/pages/index.tsx
@@ -38,15 +38,19 @@ export const getStaticProps = async (
 };
 
 const Home: NextPage<Props> = ({ count, page, posts }) => {
+  const pagination = (
+    <Pagination
+      baseUrl="/page"
+      currentPage={page}
+      limit={POSTS_LIMIT}
+      postsCount={count}
+    />
+  );
   return (
     <>
-      <Pagination
-        baseUrl="/page"
-        currentPage={page}
-        limit={POSTS_LIMIT}
-        postsCount={count}
-      />
+      {pagination}
       <Posts posts={posts} />
+      {pagination}
     </>
   );
 };

--- a/packages/blog/src/pages/page/[page].tsx
+++ b/packages/blog/src/pages/page/[page].tsx
@@ -61,19 +61,23 @@ export const getStaticProps: GetStaticProps<Props> = async (context) => {
 };
 
 const Page: NextPage<Props> = ({ count, page, posts }) => {
+  const pagination = (
+    <Pagination
+      baseUrl="/page"
+      currentPage={page}
+      limit={POSTS_LIMIT}
+      postsCount={count}
+    />
+  );
   return (
     <>
       <Head>
         <title> {page} ページ目</title>
         <meta name="robots" content="noindex,nofollow" />
       </Head>
-      <Pagination
-        baseUrl="/page"
-        currentPage={page}
-        limit={POSTS_LIMIT}
-        postsCount={count}
-      />
+      {pagination}
       <Posts posts={posts} />
+      {pagination}
     </>
   );
 };

--- a/packages/blog/src/pages/til/index.tsx
+++ b/packages/blog/src/pages/til/index.tsx
@@ -40,6 +40,14 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
 
 const Page: NextPage<Props> = ({ count, page, tils }) => {
   const breadcrumbsList = useMemo(() => generateTilsBreadcrumbsList(), []);
+  const pagination = (
+    <Pagination
+      baseUrl="/til/page"
+      currentPage={page}
+      limit={TIL_LIMIT}
+      postsCount={count}
+    />
+  );
 
   return (
     <>
@@ -47,14 +55,10 @@ const Page: NextPage<Props> = ({ count, page, tils }) => {
         <title> TIL </title>
       </Head>
       <Breadcrumbs list={breadcrumbsList} />
-      <Pagination
-        baseUrl="/til/page"
-        currentPage={page}
-        limit={TIL_LIMIT}
-        postsCount={count}
-      />
+      {pagination}
       <div className={titleStyles.title}>TIL</div>
       <Tils tils={tils} />
+      {pagination}
     </>
   );
 };

--- a/packages/blog/src/pages/til/page/[page].tsx
+++ b/packages/blog/src/pages/til/page/[page].tsx
@@ -61,6 +61,14 @@ export const getStaticProps: GetStaticProps<Props> = async (context) => {
 
 const Page: NextPage<Props> = ({ count, page, tils }) => {
   const breadcrumbsList = useMemo(() => generateTilsBreadcrumbsList(), []);
+  const pagination = (
+    <Pagination
+      baseUrl="/til/page"
+      currentPage={page}
+      limit={TIL_LIMIT}
+      postsCount={count}
+    />
+  );
 
   return (
     <>
@@ -68,14 +76,10 @@ const Page: NextPage<Props> = ({ count, page, tils }) => {
         <title> TIL {page} ページ目</title>
       </Head>
       <Breadcrumbs list={breadcrumbsList} />
-      <Pagination
-        baseUrl="/til/page"
-        currentPage={page}
-        limit={TIL_LIMIT}
-        postsCount={count}
-      />
+      {pagination}
 
       <Tils tils={tils} />
+      {pagination}
     </>
   );
 };

--- a/packages/blog/src/styles/globals.css
+++ b/packages/blog/src/styles/globals.css
@@ -33,6 +33,8 @@ body {
   /* 和文と英数字の間の四分アキと、連続する約物の詰め(対応ブラウザのみ) */
   text-autospace: normal;
   text-spacing-trim: normal;
+  /* イタリック体を持たない和文フォントの機械的な傾き(合成斜体)を禁止する */
+  font-synthesis-style: none;
 }
 
 a {

--- a/packages/blog/src/styles/globals.css
+++ b/packages/blog/src/styles/globals.css
@@ -30,6 +30,9 @@ body {
   min-height: 100vh;
   width: 100%;
   position: relative;
+  /* 和文と英数字の間の四分アキと、連続する約物の詰め(対応ブラウザのみ) */
+  text-autospace: normal;
+  text-spacing-trim: normal;
 }
 
 a {

--- a/packages/blog/src/styles/globals.css
+++ b/packages/blog/src/styles/globals.css
@@ -21,8 +21,12 @@ html,
 body {
   margin: 0;
   padding: 0;
-  font-family: Hiragino Kaku Gothic ProN, Hiragino Sans, BIZ UDPGothic, Meiryo,
-    sans-serif;
+  /* 英数字はSegoe UI(Windows)等の欧文フォント、和文は各OS標準の
+     日本語フォントで描画する。Hiragino Sansを優先することでmacOSでは
+     多ウェイト(W0-W9)が使え、font-weight指定が実際に反映される */
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Hiragino Sans,
+    Hiragino Kaku Gothic ProN, BIZ UDPGothic, Noto Sans JP, Meiryo, sans-serif,
+    Apple Color Emoji, Segoe UI Emoji;
   min-height: 100vh;
   width: 100%;
   position: relative;

--- a/packages/blog/src/styles/globals.css
+++ b/packages/blog/src/styles/globals.css
@@ -1,6 +1,5 @@
 html {
   font-size: 16px;
-  text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
@@ -24,7 +23,6 @@ body {
   padding: 0;
   font-family: Hiragino Kaku Gothic ProN, Hiragino Sans, BIZ UDPGothic, Meiryo,
     sans-serif;
-  font-weight: 500;
   min-height: 100vh;
   width: 100%;
   position: relative;


### PR DESCRIPTION
## この PR でやったこと

Webフォントを使わない制約のまま、特にWindowsでの日本語表示を改善する。コードのフォントサイズ基準の修正、実効性のないレンダリング指定の削除、本文フォントスタックの和欧混植対応、日本語組版向けモダンCSS(text-autospace / text-spacing-trim / palt / auto-phrase)の導入、記事リンクの下線復活、和文の合成斜体廃止を行った。

## 仕様/経緯

Windowsでの表示品質に課題があり、Webフォント不使用(ローカルフォントのみ)を維持したまま改善したい、が出発点。調査の結果、主因はフォント選択ではなく次の2点だった。

1. **コード要素にfont-family指定がなく、Chrome系の「総称monospace単独時は既定13px」仕様でインラインコードが本文より小さく描画されていた**([Fixed Monospace Sizing — Eric Meyer](https://meyerweb.com/eric/thoughts/2010/02/12/fixed-monospace-sizing/))
2. `font-weight: 500` は搭載ウェイトが400/700のみのBIZ UDPGothic / Meiryoでは400に解決され、`text-rendering: optimizeLegibility` / `-webkit-font-smoothing` はWindowsに効果がない([MDN font-weight — Fallback weights](https://developer.mozilla.org/ja/docs/Web/CSS/font-weight))

なお現行スタック(BIZ UDPGothic優先)自体は、Windowsの游ゴシックかすれ問題を構造的に回避できており妥当と判断してベースを維持した。

## 設計判断

### コードのフォントは閲覧者のブラウザ設定に委ねる

等幅フォントは好みが分かれるため、`Consolas` 等の具体名は列挙せず**総称 `monospace` のみ**を指定する。サイズは `rem` で指定することで、フォント選択を奪わずに13px縮小だけを解消した(remはルート基準で解決されるためこの仕様の影響を受けない)。トレードオフとして、フォント未設定のWindows閲覧者ではコード内の日本語がMS ゴシックで描画される点は許容する。

### 本文スタックは「欧文フォント先頭 + 和文明示」

```css
font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Hiragino Sans,
  Hiragino Kaku Gothic ProN, BIZ UDPGothic, Noto Sans JP, Meiryo, sans-serif,
  Apple Color Emoji, Segoe UI Emoji;
```

- BIZ UDPGothicの欧文・数字グリフは詰まり気味なため、英数字をSegoe UI(Windows) / SF Pro(macOS)に任せる。Qiitaの現行本文スタックとほぼ同型
- `Hiragino Sans` を `ProN` より先に置くことで、macOSで多ウェイト(W0〜W9)が使えるようにする(和文本文はW3→W4相当に少し締まる)
- `Noto Sans JP` はWindows 11 24H2以降で標準搭載が始まったとされるため(二次情報)、BIZ UDPGothic非搭載環境(非日本語ロケール等)のフォールバックとして追加
- `system-ui` はWindowsでYu Gothic UI(字間異常・約物の重なりバグあり)になるため使わない

### モダンCSSはプログレッシブエンハンスメントとして導入

いずれも未対応ブラウザでは無視され従来表示になる(2026-07時点の対応状況)。

| プロパティ | Chrome/Edge | Safari | Firefox |
|---|---|---|---|
| `text-autospace: normal`(和欧間アキ) | 140+ | 18.4+ | 145+ |
| `text-spacing-trim: normal`(約物詰め) | 123+(既定で有効) | ✕ | ✕ |
| `word-break: auto-phrase`(文節改行) | 119+ | ✕ | ✕ |
| `text-wrap: balance` | 114+ | 17.5+ | 121+ |
| `font-synthesis-style: none` | 97+ | 16.4+ | 111+ |

- `text-autospace` は記事が textlint の JTF スタイル(和欧間に手動スペースを入れない)で書かれているため、二重アキなく全記事に一括で効く
- `word-break: auto-phrase` は [Chrome公式が「見出しなど短いテキスト向け」と明言](https://developer.chrome.com/blog/css-i18n-features)しているため(> \"apply it to short text such as headings\")、見出しと記事タイトルに限定。コードブロックでは桁揃え維持のため両プロパティを無効化
- `em`(斜体強調)は和文フォントにイタリック体がなく、Windowsでは機械的に傾けた合成斜体で汚く描画されるため、合成斜体を禁止し太さ(600)による強調へ置き換えた

## 動作確認した手順

- [ ] Windows実機(非HiDPI・100%スケーリングが最悪ケース)のChrome/Edgeで記事ページを表示し、DevTools > Computed > Rendered Fonts で本文=BIZ UDPGothic・英数字=Segoe UIになっていること
- [ ] インラインコードのサイズが本文と釣り合っていること(旧: Chrome系で13px)
- [ ] 見出し・記事タイトルが文節単位で折り返されること(Chrome/Edge)
- [ ] 「TypeScriptの型」のような和欧境界にアキが入ること(Chrome 140+ / Safari 18.4+)
- [ ] 記事本文リンクの下線位置・太さに違和感がないこと
- [ ] `*強調*`(em)を含む既存記事で、斜体でなく太字表示になること
- [ ] macOSで本文がわずかに太く(W3→W4相当)、英数字がSF Proになった見た目を許容できること
- [ ] ダークモードでの見え方に劣化がないこと

## 影響範囲

- 本文フォントスタック・text-autospace等は**全ページ**(html/body)に効く
- 下線・em・見出し組版・コードサイズは**記事本文(.postBody)と記事タイトル**のみ
- 記事データ・ビルド設定への変更はなし(`corepack yarn build` 成功確認済み)

## そのた

### コミットの流れ

1. `fix: コードのフォントサイズ基準を本文と揃える` — 13px問題の解消(monospace + rem)
2. `refactor: 実効性のないレンダリング指定を削除` — font-weight: 500 / optimizeLegibility
3. `feat: 本文フォントスタックを和欧混植向けに改良` — 欧文先頭 + Noto Sans JP追加
4. `feat: 日本語組版向けのモダンCSSを導入` — autospace / trim / palt / auto-phrase / balance
5. `feat: 記事本文のリンクに下線を表示`
6. `feat: 和文の合成斜体を廃止し強調をウェイトで表現`

1〜2が「壊れていたものの修正」、3〜6が「組版品質の向上」です。

### 今回やらなかったこと

- 記事カラム幅816px(全角約49字/行)の縮小 — WCAG 1.4.8はCJK 40字/行以下を推奨するが、レイアウトの印象が大きく変わるため別途判断
- `text-spacing-trim` / `palt` がBIZ UDPGothicで実際に効くか(OpenTypeのhalt/palt収録)は一次情報未確認。効かない場合も表示は従来どおりで劣化はない

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)